### PR TITLE
Add banner warning of outdated documentation to all RTD-themed pages

### DIFF
--- a/0.49.0/cuda-reference/host.html
+++ b/0.49.0/cuda-reference/host.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-host-api">

--- a/0.49.0/cuda-reference/index.html
+++ b/0.49.0/cuda-reference/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-python-reference">

--- a/0.49.0/cuda-reference/kernel.html
+++ b/0.49.0/cuda-reference/kernel.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-kernel-api">

--- a/0.49.0/cuda-reference/memory.html
+++ b/0.49.0/cuda-reference/memory.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.49.0/cuda/cuda_array_interface.html
+++ b/0.49.0/cuda/cuda_array_interface.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-array-interface-version-2">

--- a/0.49.0/cuda/cudapysupported.html
+++ b/0.49.0/cuda/cudapysupported.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features-in-cuda-python">

--- a/0.49.0/cuda/device-functions.html
+++ b/0.49.0/cuda/device-functions.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/0.49.0/cuda/device-management.html
+++ b/0.49.0/cuda/device-management.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="device-management">

--- a/0.49.0/cuda/examples.html
+++ b/0.49.0/cuda/examples.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.49.0/cuda/external-memory.html
+++ b/0.49.0/cuda/external-memory.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="external-memory-management-emm-plugin-interface">

--- a/0.49.0/cuda/faq.html
+++ b/0.49.0/cuda/faq.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-frequently-asked-questions">

--- a/0.49.0/cuda/index.html
+++ b/0.49.0/cuda/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-cuda-gpus">

--- a/0.49.0/cuda/intrinsics.html
+++ b/0.49.0/cuda/intrinsics.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/0.49.0/cuda/ipc.html
+++ b/0.49.0/cuda/ipc.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="sharing-cuda-memory">

--- a/0.49.0/cuda/kernels.html
+++ b/0.49.0/cuda/kernels.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-cuda-kernels">

--- a/0.49.0/cuda/memory.html
+++ b/0.49.0/cuda/memory.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.49.0/cuda/overview.html
+++ b/0.49.0/cuda/overview.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.49.0/cuda/random.html
+++ b/0.49.0/cuda/random.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="random-number-generation">

--- a/0.49.0/cuda/reduction.html
+++ b/0.49.0/cuda/reduction.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="gpu-reduction">

--- a/0.49.0/cuda/simulator.html
+++ b/0.49.0/cuda/simulator.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="debugging-cuda-python-with-the-the-cuda-simulator">

--- a/0.49.0/cuda/ufunc.html
+++ b/0.49.0/cuda/ufunc.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-ufuncs-and-generalized-ufuncs">

--- a/0.49.0/developer/architecture.html
+++ b/0.49.0/developer/architecture.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-architecture">

--- a/0.49.0/developer/autogen_builtins_listing.html
+++ b/0.49.0/developer/autogen_builtins_listing.html
@@ -1242,6 +1242,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-builtins">

--- a/0.49.0/developer/autogen_cmath_listing.html
+++ b/0.49.0/developer/autogen_cmath_listing.html
@@ -1242,6 +1242,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-cmath">

--- a/0.49.0/developer/autogen_lower_listing.html
+++ b/0.49.0/developer/autogen_lower_listing.html
@@ -1242,6 +1242,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="lowering-listing">

--- a/0.49.0/developer/autogen_math_listing.html
+++ b/0.49.0/developer/autogen_math_listing.html
@@ -1242,6 +1242,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-math">

--- a/0.49.0/developer/autogen_numpy_listing.html
+++ b/0.49.0/developer/autogen_numpy_listing.html
@@ -1242,6 +1242,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-numpy">

--- a/0.49.0/developer/caching.html
+++ b/0.49.0/developer/caching.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-caching">

--- a/0.49.0/developer/contributing.html
+++ b/0.49.0/developer/contributing.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="contributing-to-numba">

--- a/0.49.0/developer/custom_pipeline.html
+++ b/0.49.0/developer/custom_pipeline.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="customizing-the-compiler">

--- a/0.49.0/developer/debugging.html
+++ b/0.49.0/developer/debugging.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-debugging">

--- a/0.49.0/developer/dispatching.html
+++ b/0.49.0/developer/dispatching.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="polymorphic-dispatching">

--- a/0.49.0/developer/environment.html
+++ b/0.49.0/developer/environment.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-object">

--- a/0.49.0/developer/generators.html
+++ b/0.49.0/developer/generators.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-generators">

--- a/0.49.0/developer/hashing.html
+++ b/0.49.0/developer/hashing.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-hashing">

--- a/0.49.0/developer/index.html
+++ b/0.49.0/developer/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="developer-manual">

--- a/0.49.0/developer/inlining.html
+++ b/0.49.0/developer/inlining.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-inlining">

--- a/0.49.0/developer/listings.html
+++ b/0.49.0/developer/listings.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings">

--- a/0.49.0/developer/literal.html
+++ b/0.49.0/developer/literal.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-literal-types">

--- a/0.49.0/developer/live_variable_analysis.html
+++ b/0.49.0/developer/live_variable_analysis.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="live-variable-analysis">

--- a/0.49.0/developer/numba-runtime.html
+++ b/0.49.0/developer/numba-runtime.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-runtime">

--- a/0.49.0/developer/repomap.html
+++ b/0.49.0/developer/repomap.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-map-of-the-numba-repository">

--- a/0.49.0/developer/rewrites.html
+++ b/0.49.0/developer/rewrites.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-numba-rewrite-pass-for-fun-and-optimization">

--- a/0.49.0/developer/roadmap.html
+++ b/0.49.0/developer/roadmap.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-project-roadmap">

--- a/0.49.0/developer/stencil.html
+++ b/0.49.0/developer/stencil.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-stencils">

--- a/0.49.0/developer/threading_implementation.html
+++ b/0.49.0/developer/threading_implementation.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-s-threading-implementation">

--- a/0.49.0/extending/entrypoints.html
+++ b/0.49.0/extending/entrypoints.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="registering-extensions-with-entry-points">

--- a/0.49.0/extending/high-level.html
+++ b/0.49.0/extending/high-level.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="high-level-extension-api">

--- a/0.49.0/extending/index.html
+++ b/0.49.0/extending/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="module-numba.extending">

--- a/0.49.0/extending/interval-example.html
+++ b/0.49.0/extending/interval-example.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="example-an-interval-type">

--- a/0.49.0/extending/low-level.html
+++ b/0.49.0/extending/low-level.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="low-level-extension-api">

--- a/0.49.0/extending/overloading-guide.html
+++ b/0.49.0/extending/overloading-guide.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-guide-to-using-overload">

--- a/0.49.0/genindex.html
+++ b/0.49.0/genindex.html
@@ -1235,6 +1235,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/0.49.0/glossary.html
+++ b/0.49.0/glossary.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="glossary">

--- a/0.49.0/index.html
+++ b/0.49.0/index.html
@@ -1237,6 +1237,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-documentation">

--- a/0.49.0/proposals/cfunc.html
+++ b/0.49.0/proposals/cfunc.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-4-defining-c-callbacks">

--- a/0.49.0/proposals/extension-points.html
+++ b/0.49.0/proposals/extension-points.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-2-extension-points">

--- a/0.49.0/proposals/external-memory-management.html
+++ b/0.49.0/proposals/external-memory-management.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-7-cuda-external-memory-management-plugins">

--- a/0.49.0/proposals/index.html
+++ b/0.49.0/proposals/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-enhancement-proposals">

--- a/0.49.0/proposals/integer-typing.html
+++ b/0.49.0/proposals/integer-typing.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-1-changes-in-integer-typing">

--- a/0.49.0/proposals/jit-classes.html
+++ b/0.49.0/proposals/jit-classes.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-3-jit-classes">

--- a/0.49.0/proposals/type-inference.html
+++ b/0.49.0/proposals/type-inference.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-5-type-inference">

--- a/0.49.0/proposals/typing_recursion.html
+++ b/0.49.0/proposals/typing_recursion.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-6-typing-recursion">

--- a/0.49.0/py-modindex.html
+++ b/0.49.0/py-modindex.html
@@ -1235,6 +1235,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/0.49.0/reference/aot-compilation.html
+++ b/0.49.0/reference/aot-compilation.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="ahead-of-time-compilation">

--- a/0.49.0/reference/deprecation.html
+++ b/0.49.0/reference/deprecation.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deprecation-notices">

--- a/0.49.0/reference/envvars.html
+++ b/0.49.0/reference/envvars.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-variables">

--- a/0.49.0/reference/fpsemantics.html
+++ b/0.49.0/reference/fpsemantics.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="floating-point-pitfalls">

--- a/0.49.0/reference/index.html
+++ b/0.49.0/reference/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="reference-manual">

--- a/0.49.0/reference/jit-compilation.html
+++ b/0.49.0/reference/jit-compilation.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="just-in-time-compilation">

--- a/0.49.0/reference/numpysupported.html
+++ b/0.49.0/reference/numpysupported.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-numpy-features">

--- a/0.49.0/reference/pysemantics.html
+++ b/0.49.0/reference/pysemantics.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deviations-from-python-semantics">

--- a/0.49.0/reference/pysupported.html
+++ b/0.49.0/reference/pysupported.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features">

--- a/0.49.0/reference/python27-eol.html
+++ b/0.49.0/reference/python27-eol.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="python-2-7-end-of-life-plan">

--- a/0.49.0/reference/types.html
+++ b/0.49.0/reference/types.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="types-and-signatures">

--- a/0.49.0/reference/utils.html
+++ b/0.49.0/reference/utils.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="utilities">

--- a/0.49.0/release-notes.html
+++ b/0.49.0/release-notes.html
@@ -1237,6 +1237,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="release-notes">

--- a/0.49.0/roc/device-functions.html
+++ b/0.49.0/roc/device-functions.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/0.49.0/roc/device-management.html
+++ b/0.49.0/roc/device-management.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-agents">

--- a/0.49.0/roc/examples.html
+++ b/0.49.0/roc/examples.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.49.0/roc/index.html
+++ b/0.49.0/roc/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-amd-roc-gpus">

--- a/0.49.0/roc/intrinsics.html
+++ b/0.49.0/roc/intrinsics.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/0.49.0/roc/kernels.html
+++ b/0.49.0/roc/kernels.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-hsa-kernels">

--- a/0.49.0/roc/memory.html
+++ b/0.49.0/roc/memory.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.49.0/roc/overview.html
+++ b/0.49.0/roc/overview.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.49.0/roc/ufunc.html
+++ b/0.49.0/roc/ufunc.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="roc-ufuncs-and-generalized-ufuncs">

--- a/0.49.0/search.html
+++ b/0.49.0/search.html
@@ -1234,6 +1234,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <noscript>

--- a/0.49.0/user/5minguide.html
+++ b/0.49.0/user/5minguide.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-5-minute-guide-to-numba">

--- a/0.49.0/user/cfunc.html
+++ b/0.49.0/user/cfunc.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-c-callbacks-with-cfunc">

--- a/0.49.0/user/cli.html
+++ b/0.49.0/user/cli.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="command-line-interface">

--- a/0.49.0/user/examples.html
+++ b/0.49.0/user/examples.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.49.0/user/faq.html
+++ b/0.49.0/user/faq.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="frequently-asked-questions">

--- a/0.49.0/user/generated-jit.html
+++ b/0.49.0/user/generated-jit.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="flexible-specializations-with-generated-jit">

--- a/0.49.0/user/index.html
+++ b/0.49.0/user/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="user-manual">

--- a/0.49.0/user/installing.html
+++ b/0.49.0/user/installing.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="installation">

--- a/0.49.0/user/jit-module.html
+++ b/0.49.0/user/jit-module.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-module-jitting-with-jit-module">

--- a/0.49.0/user/jit.html
+++ b/0.49.0/user/jit.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-code-with-jit">

--- a/0.49.0/user/jitclass.html
+++ b/0.49.0/user/jitclass.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-classes-with-jitclass">

--- a/0.49.0/user/overview.html
+++ b/0.49.0/user/overview.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.49.0/user/parallel.html
+++ b/0.49.0/user/parallel.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-parallelization-with-jit">

--- a/0.49.0/user/performance-tips.html
+++ b/0.49.0/user/performance-tips.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="performance-tips">

--- a/0.49.0/user/pycc.html
+++ b/0.49.0/user/pycc.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-code-ahead-of-time">

--- a/0.49.0/user/stencil.html
+++ b/0.49.0/user/stencil.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-stencil-decorator">

--- a/0.49.0/user/talks.html
+++ b/0.49.0/user/talks.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="talks-and-tutorials">

--- a/0.49.0/user/threading-layer.html
+++ b/0.49.0/user/threading-layer.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-threading-layers">

--- a/0.49.0/user/troubleshoot.html
+++ b/0.49.0/user/troubleshoot.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="troubleshooting-and-tips">

--- a/0.49.0/user/vectorize.html
+++ b/0.49.0/user/vectorize.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-numpy-universal-functions">

--- a/0.49.0/user/withobjmode.html
+++ b/0.49.0/user/withobjmode.html
@@ -1240,6 +1240,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="callback-into-the-python-interpreter-from-within-jit-ed-code">

--- a/0.49.1/cuda-reference/host.html
+++ b/0.49.1/cuda-reference/host.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-host-api">

--- a/0.49.1/cuda-reference/index.html
+++ b/0.49.1/cuda-reference/index.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-python-reference">

--- a/0.49.1/cuda-reference/kernel.html
+++ b/0.49.1/cuda-reference/kernel.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-kernel-api">

--- a/0.49.1/cuda-reference/memory.html
+++ b/0.49.1/cuda-reference/memory.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.49.1/cuda/cuda_array_interface.html
+++ b/0.49.1/cuda/cuda_array_interface.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-array-interface-version-2">

--- a/0.49.1/cuda/cudapysupported.html
+++ b/0.49.1/cuda/cudapysupported.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features-in-cuda-python">

--- a/0.49.1/cuda/device-functions.html
+++ b/0.49.1/cuda/device-functions.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/0.49.1/cuda/device-management.html
+++ b/0.49.1/cuda/device-management.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="device-management">

--- a/0.49.1/cuda/examples.html
+++ b/0.49.1/cuda/examples.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.49.1/cuda/external-memory.html
+++ b/0.49.1/cuda/external-memory.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="external-memory-management-emm-plugin-interface">

--- a/0.49.1/cuda/faq.html
+++ b/0.49.1/cuda/faq.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-frequently-asked-questions">

--- a/0.49.1/cuda/index.html
+++ b/0.49.1/cuda/index.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-cuda-gpus">

--- a/0.49.1/cuda/intrinsics.html
+++ b/0.49.1/cuda/intrinsics.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/0.49.1/cuda/ipc.html
+++ b/0.49.1/cuda/ipc.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="sharing-cuda-memory">

--- a/0.49.1/cuda/kernels.html
+++ b/0.49.1/cuda/kernels.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-cuda-kernels">

--- a/0.49.1/cuda/memory.html
+++ b/0.49.1/cuda/memory.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.49.1/cuda/overview.html
+++ b/0.49.1/cuda/overview.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.49.1/cuda/random.html
+++ b/0.49.1/cuda/random.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="random-number-generation">

--- a/0.49.1/cuda/reduction.html
+++ b/0.49.1/cuda/reduction.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="gpu-reduction">

--- a/0.49.1/cuda/simulator.html
+++ b/0.49.1/cuda/simulator.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="debugging-cuda-python-with-the-the-cuda-simulator">

--- a/0.49.1/cuda/ufunc.html
+++ b/0.49.1/cuda/ufunc.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-ufuncs-and-generalized-ufuncs">

--- a/0.49.1/developer/architecture.html
+++ b/0.49.1/developer/architecture.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-architecture">

--- a/0.49.1/developer/autogen_builtins_listing.html
+++ b/0.49.1/developer/autogen_builtins_listing.html
@@ -1243,6 +1243,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-builtins">

--- a/0.49.1/developer/autogen_cmath_listing.html
+++ b/0.49.1/developer/autogen_cmath_listing.html
@@ -1243,6 +1243,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-cmath">

--- a/0.49.1/developer/autogen_lower_listing.html
+++ b/0.49.1/developer/autogen_lower_listing.html
@@ -1243,6 +1243,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="lowering-listing">

--- a/0.49.1/developer/autogen_math_listing.html
+++ b/0.49.1/developer/autogen_math_listing.html
@@ -1243,6 +1243,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-math">

--- a/0.49.1/developer/autogen_numpy_listing.html
+++ b/0.49.1/developer/autogen_numpy_listing.html
@@ -1243,6 +1243,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-numpy">

--- a/0.49.1/developer/caching.html
+++ b/0.49.1/developer/caching.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-caching">

--- a/0.49.1/developer/contributing.html
+++ b/0.49.1/developer/contributing.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="contributing-to-numba">

--- a/0.49.1/developer/custom_pipeline.html
+++ b/0.49.1/developer/custom_pipeline.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="customizing-the-compiler">

--- a/0.49.1/developer/debugging.html
+++ b/0.49.1/developer/debugging.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-debugging">

--- a/0.49.1/developer/dispatching.html
+++ b/0.49.1/developer/dispatching.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="polymorphic-dispatching">

--- a/0.49.1/developer/environment.html
+++ b/0.49.1/developer/environment.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-object">

--- a/0.49.1/developer/generators.html
+++ b/0.49.1/developer/generators.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-generators">

--- a/0.49.1/developer/hashing.html
+++ b/0.49.1/developer/hashing.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-hashing">

--- a/0.49.1/developer/index.html
+++ b/0.49.1/developer/index.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="developer-manual">

--- a/0.49.1/developer/inlining.html
+++ b/0.49.1/developer/inlining.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-inlining">

--- a/0.49.1/developer/listings.html
+++ b/0.49.1/developer/listings.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings">

--- a/0.49.1/developer/literal.html
+++ b/0.49.1/developer/literal.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-literal-types">

--- a/0.49.1/developer/live_variable_analysis.html
+++ b/0.49.1/developer/live_variable_analysis.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="live-variable-analysis">

--- a/0.49.1/developer/numba-runtime.html
+++ b/0.49.1/developer/numba-runtime.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-runtime">

--- a/0.49.1/developer/repomap.html
+++ b/0.49.1/developer/repomap.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-map-of-the-numba-repository">

--- a/0.49.1/developer/rewrites.html
+++ b/0.49.1/developer/rewrites.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-numba-rewrite-pass-for-fun-and-optimization">

--- a/0.49.1/developer/roadmap.html
+++ b/0.49.1/developer/roadmap.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-project-roadmap">

--- a/0.49.1/developer/stencil.html
+++ b/0.49.1/developer/stencil.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-stencils">

--- a/0.49.1/developer/threading_implementation.html
+++ b/0.49.1/developer/threading_implementation.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-s-threading-implementation">

--- a/0.49.1/extending/entrypoints.html
+++ b/0.49.1/extending/entrypoints.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="registering-extensions-with-entry-points">

--- a/0.49.1/extending/high-level.html
+++ b/0.49.1/extending/high-level.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="high-level-extension-api">

--- a/0.49.1/extending/index.html
+++ b/0.49.1/extending/index.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="module-numba.extending">

--- a/0.49.1/extending/interval-example.html
+++ b/0.49.1/extending/interval-example.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="example-an-interval-type">

--- a/0.49.1/extending/low-level.html
+++ b/0.49.1/extending/low-level.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="low-level-extension-api">

--- a/0.49.1/extending/overloading-guide.html
+++ b/0.49.1/extending/overloading-guide.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-guide-to-using-overload">

--- a/0.49.1/genindex.html
+++ b/0.49.1/genindex.html
@@ -1236,6 +1236,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/0.49.1/glossary.html
+++ b/0.49.1/glossary.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="glossary">

--- a/0.49.1/index.html
+++ b/0.49.1/index.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-documentation">

--- a/0.49.1/proposals/cfunc.html
+++ b/0.49.1/proposals/cfunc.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-4-defining-c-callbacks">

--- a/0.49.1/proposals/extension-points.html
+++ b/0.49.1/proposals/extension-points.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-2-extension-points">

--- a/0.49.1/proposals/external-memory-management.html
+++ b/0.49.1/proposals/external-memory-management.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-7-cuda-external-memory-management-plugins">

--- a/0.49.1/proposals/index.html
+++ b/0.49.1/proposals/index.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-enhancement-proposals">

--- a/0.49.1/proposals/integer-typing.html
+++ b/0.49.1/proposals/integer-typing.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-1-changes-in-integer-typing">

--- a/0.49.1/proposals/jit-classes.html
+++ b/0.49.1/proposals/jit-classes.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-3-jit-classes">

--- a/0.49.1/proposals/type-inference.html
+++ b/0.49.1/proposals/type-inference.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-5-type-inference">

--- a/0.49.1/proposals/typing_recursion.html
+++ b/0.49.1/proposals/typing_recursion.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-6-typing-recursion">

--- a/0.49.1/py-modindex.html
+++ b/0.49.1/py-modindex.html
@@ -1236,6 +1236,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/0.49.1/reference/aot-compilation.html
+++ b/0.49.1/reference/aot-compilation.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="ahead-of-time-compilation">

--- a/0.49.1/reference/deprecation.html
+++ b/0.49.1/reference/deprecation.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deprecation-notices">

--- a/0.49.1/reference/envvars.html
+++ b/0.49.1/reference/envvars.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-variables">

--- a/0.49.1/reference/fpsemantics.html
+++ b/0.49.1/reference/fpsemantics.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="floating-point-pitfalls">

--- a/0.49.1/reference/index.html
+++ b/0.49.1/reference/index.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="reference-manual">

--- a/0.49.1/reference/jit-compilation.html
+++ b/0.49.1/reference/jit-compilation.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="just-in-time-compilation">

--- a/0.49.1/reference/numpysupported.html
+++ b/0.49.1/reference/numpysupported.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-numpy-features">

--- a/0.49.1/reference/pysemantics.html
+++ b/0.49.1/reference/pysemantics.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deviations-from-python-semantics">

--- a/0.49.1/reference/pysupported.html
+++ b/0.49.1/reference/pysupported.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features">

--- a/0.49.1/reference/python27-eol.html
+++ b/0.49.1/reference/python27-eol.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="python-2-7-end-of-life-plan">

--- a/0.49.1/reference/types.html
+++ b/0.49.1/reference/types.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="types-and-signatures">

--- a/0.49.1/reference/utils.html
+++ b/0.49.1/reference/utils.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="utilities">

--- a/0.49.1/release-notes.html
+++ b/0.49.1/release-notes.html
@@ -1238,6 +1238,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="release-notes">

--- a/0.49.1/roc/device-functions.html
+++ b/0.49.1/roc/device-functions.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/0.49.1/roc/device-management.html
+++ b/0.49.1/roc/device-management.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-agents">

--- a/0.49.1/roc/examples.html
+++ b/0.49.1/roc/examples.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.49.1/roc/index.html
+++ b/0.49.1/roc/index.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-amd-roc-gpus">

--- a/0.49.1/roc/intrinsics.html
+++ b/0.49.1/roc/intrinsics.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/0.49.1/roc/kernels.html
+++ b/0.49.1/roc/kernels.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-hsa-kernels">

--- a/0.49.1/roc/memory.html
+++ b/0.49.1/roc/memory.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.49.1/roc/overview.html
+++ b/0.49.1/roc/overview.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.49.1/roc/ufunc.html
+++ b/0.49.1/roc/ufunc.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="roc-ufuncs-and-generalized-ufuncs">

--- a/0.49.1/search.html
+++ b/0.49.1/search.html
@@ -1235,6 +1235,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <noscript>

--- a/0.49.1/user/5minguide.html
+++ b/0.49.1/user/5minguide.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-5-minute-guide-to-numba">

--- a/0.49.1/user/cfunc.html
+++ b/0.49.1/user/cfunc.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-c-callbacks-with-cfunc">

--- a/0.49.1/user/cli.html
+++ b/0.49.1/user/cli.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="command-line-interface">

--- a/0.49.1/user/examples.html
+++ b/0.49.1/user/examples.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.49.1/user/faq.html
+++ b/0.49.1/user/faq.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="frequently-asked-questions">

--- a/0.49.1/user/generated-jit.html
+++ b/0.49.1/user/generated-jit.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="flexible-specializations-with-generated-jit">

--- a/0.49.1/user/index.html
+++ b/0.49.1/user/index.html
@@ -1239,6 +1239,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="user-manual">

--- a/0.49.1/user/installing.html
+++ b/0.49.1/user/installing.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="installation">

--- a/0.49.1/user/jit-module.html
+++ b/0.49.1/user/jit-module.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-module-jitting-with-jit-module">

--- a/0.49.1/user/jit.html
+++ b/0.49.1/user/jit.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-code-with-jit">

--- a/0.49.1/user/jitclass.html
+++ b/0.49.1/user/jitclass.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-classes-with-jitclass">

--- a/0.49.1/user/overview.html
+++ b/0.49.1/user/overview.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.49.1/user/parallel.html
+++ b/0.49.1/user/parallel.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-parallelization-with-jit">

--- a/0.49.1/user/performance-tips.html
+++ b/0.49.1/user/performance-tips.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="performance-tips">

--- a/0.49.1/user/pycc.html
+++ b/0.49.1/user/pycc.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-code-ahead-of-time">

--- a/0.49.1/user/stencil.html
+++ b/0.49.1/user/stencil.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-stencil-decorator">

--- a/0.49.1/user/talks.html
+++ b/0.49.1/user/talks.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="talks-and-tutorials">

--- a/0.49.1/user/threading-layer.html
+++ b/0.49.1/user/threading-layer.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-threading-layers">

--- a/0.49.1/user/troubleshoot.html
+++ b/0.49.1/user/troubleshoot.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="troubleshooting-and-tips">

--- a/0.49.1/user/vectorize.html
+++ b/0.49.1/user/vectorize.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-numpy-universal-functions">

--- a/0.49.1/user/withobjmode.html
+++ b/0.49.1/user/withobjmode.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="callback-into-the-python-interpreter-from-within-jit-ed-code">

--- a/0.50.0/cuda-reference/host.html
+++ b/0.50.0/cuda-reference/host.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-host-api">

--- a/0.50.0/cuda-reference/index.html
+++ b/0.50.0/cuda-reference/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-python-reference">

--- a/0.50.0/cuda-reference/kernel.html
+++ b/0.50.0/cuda-reference/kernel.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-kernel-api">

--- a/0.50.0/cuda-reference/memory.html
+++ b/0.50.0/cuda-reference/memory.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.50.0/cuda/cuda_array_interface.html
+++ b/0.50.0/cuda/cuda_array_interface.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-array-interface-version-2">

--- a/0.50.0/cuda/cudapysupported.html
+++ b/0.50.0/cuda/cudapysupported.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features-in-cuda-python">

--- a/0.50.0/cuda/device-functions.html
+++ b/0.50.0/cuda/device-functions.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/0.50.0/cuda/device-management.html
+++ b/0.50.0/cuda/device-management.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="device-management">

--- a/0.50.0/cuda/examples.html
+++ b/0.50.0/cuda/examples.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.50.0/cuda/external-memory.html
+++ b/0.50.0/cuda/external-memory.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="external-memory-management-emm-plugin-interface">

--- a/0.50.0/cuda/faq.html
+++ b/0.50.0/cuda/faq.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-frequently-asked-questions">

--- a/0.50.0/cuda/index.html
+++ b/0.50.0/cuda/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-cuda-gpus">

--- a/0.50.0/cuda/intrinsics.html
+++ b/0.50.0/cuda/intrinsics.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/0.50.0/cuda/ipc.html
+++ b/0.50.0/cuda/ipc.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="sharing-cuda-memory">

--- a/0.50.0/cuda/kernels.html
+++ b/0.50.0/cuda/kernels.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-cuda-kernels">

--- a/0.50.0/cuda/memory.html
+++ b/0.50.0/cuda/memory.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.50.0/cuda/overview.html
+++ b/0.50.0/cuda/overview.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.50.0/cuda/random.html
+++ b/0.50.0/cuda/random.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="random-number-generation">

--- a/0.50.0/cuda/reduction.html
+++ b/0.50.0/cuda/reduction.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="gpu-reduction">

--- a/0.50.0/cuda/simulator.html
+++ b/0.50.0/cuda/simulator.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="debugging-cuda-python-with-the-the-cuda-simulator">

--- a/0.50.0/cuda/ufunc.html
+++ b/0.50.0/cuda/ufunc.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-ufuncs-and-generalized-ufuncs">

--- a/0.50.0/developer/architecture.html
+++ b/0.50.0/developer/architecture.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-architecture">

--- a/0.50.0/developer/autogen_builtins_listing.html
+++ b/0.50.0/developer/autogen_builtins_listing.html
@@ -1248,6 +1248,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-builtins">

--- a/0.50.0/developer/autogen_cmath_listing.html
+++ b/0.50.0/developer/autogen_cmath_listing.html
@@ -1248,6 +1248,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-cmath">

--- a/0.50.0/developer/autogen_lower_listing.html
+++ b/0.50.0/developer/autogen_lower_listing.html
@@ -1248,6 +1248,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="lowering-listing">

--- a/0.50.0/developer/autogen_math_listing.html
+++ b/0.50.0/developer/autogen_math_listing.html
@@ -1248,6 +1248,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-math">

--- a/0.50.0/developer/autogen_numpy_listing.html
+++ b/0.50.0/developer/autogen_numpy_listing.html
@@ -1248,6 +1248,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-numpy">

--- a/0.50.0/developer/caching.html
+++ b/0.50.0/developer/caching.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-caching">

--- a/0.50.0/developer/contributing.html
+++ b/0.50.0/developer/contributing.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="contributing-to-numba">

--- a/0.50.0/developer/custom_pipeline.html
+++ b/0.50.0/developer/custom_pipeline.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="customizing-the-compiler">

--- a/0.50.0/developer/debugging.html
+++ b/0.50.0/developer/debugging.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-debugging">

--- a/0.50.0/developer/dispatching.html
+++ b/0.50.0/developer/dispatching.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="polymorphic-dispatching">

--- a/0.50.0/developer/environment.html
+++ b/0.50.0/developer/environment.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-object">

--- a/0.50.0/developer/generators.html
+++ b/0.50.0/developer/generators.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-generators">

--- a/0.50.0/developer/hashing.html
+++ b/0.50.0/developer/hashing.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-hashing">

--- a/0.50.0/developer/index.html
+++ b/0.50.0/developer/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="developer-manual">

--- a/0.50.0/developer/inlining.html
+++ b/0.50.0/developer/inlining.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-inlining">

--- a/0.50.0/developer/listings.html
+++ b/0.50.0/developer/listings.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings">

--- a/0.50.0/developer/literal.html
+++ b/0.50.0/developer/literal.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-literal-types">

--- a/0.50.0/developer/live_variable_analysis.html
+++ b/0.50.0/developer/live_variable_analysis.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="live-variable-analysis">

--- a/0.50.0/developer/numba-runtime.html
+++ b/0.50.0/developer/numba-runtime.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-runtime">

--- a/0.50.0/developer/repomap.html
+++ b/0.50.0/developer/repomap.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-map-of-the-numba-repository">

--- a/0.50.0/developer/rewrites.html
+++ b/0.50.0/developer/rewrites.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-numba-rewrite-pass-for-fun-and-optimization">

--- a/0.50.0/developer/roadmap.html
+++ b/0.50.0/developer/roadmap.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-project-roadmap">

--- a/0.50.0/developer/stencil.html
+++ b/0.50.0/developer/stencil.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-stencils">

--- a/0.50.0/developer/threading_implementation.html
+++ b/0.50.0/developer/threading_implementation.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-s-threading-implementation">

--- a/0.50.0/extending/entrypoints.html
+++ b/0.50.0/extending/entrypoints.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="registering-extensions-with-entry-points">

--- a/0.50.0/extending/high-level.html
+++ b/0.50.0/extending/high-level.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="high-level-extension-api">

--- a/0.50.0/extending/index.html
+++ b/0.50.0/extending/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="module-numba.extending">

--- a/0.50.0/extending/interval-example.html
+++ b/0.50.0/extending/interval-example.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="example-an-interval-type">

--- a/0.50.0/extending/low-level.html
+++ b/0.50.0/extending/low-level.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="low-level-extension-api">

--- a/0.50.0/extending/overloading-guide.html
+++ b/0.50.0/extending/overloading-guide.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-guide-to-using-overload">

--- a/0.50.0/genindex.html
+++ b/0.50.0/genindex.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/0.50.0/glossary.html
+++ b/0.50.0/glossary.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="glossary">

--- a/0.50.0/index.html
+++ b/0.50.0/index.html
@@ -1243,6 +1243,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-documentation">

--- a/0.50.0/proposals/cfunc.html
+++ b/0.50.0/proposals/cfunc.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-4-defining-c-callbacks">

--- a/0.50.0/proposals/extension-points.html
+++ b/0.50.0/proposals/extension-points.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-2-extension-points">

--- a/0.50.0/proposals/external-memory-management.html
+++ b/0.50.0/proposals/external-memory-management.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-7-cuda-external-memory-management-plugins">

--- a/0.50.0/proposals/index.html
+++ b/0.50.0/proposals/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-enhancement-proposals">

--- a/0.50.0/proposals/integer-typing.html
+++ b/0.50.0/proposals/integer-typing.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-1-changes-in-integer-typing">

--- a/0.50.0/proposals/jit-classes.html
+++ b/0.50.0/proposals/jit-classes.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-3-jit-classes">

--- a/0.50.0/proposals/type-inference.html
+++ b/0.50.0/proposals/type-inference.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-5-type-inference">

--- a/0.50.0/proposals/typing_recursion.html
+++ b/0.50.0/proposals/typing_recursion.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-6-typing-recursion">

--- a/0.50.0/py-modindex.html
+++ b/0.50.0/py-modindex.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/0.50.0/reference/aot-compilation.html
+++ b/0.50.0/reference/aot-compilation.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="ahead-of-time-compilation">

--- a/0.50.0/reference/deprecation.html
+++ b/0.50.0/reference/deprecation.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deprecation-notices">

--- a/0.50.0/reference/envvars.html
+++ b/0.50.0/reference/envvars.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-variables">

--- a/0.50.0/reference/fpsemantics.html
+++ b/0.50.0/reference/fpsemantics.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="floating-point-pitfalls">

--- a/0.50.0/reference/index.html
+++ b/0.50.0/reference/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="reference-manual">

--- a/0.50.0/reference/jit-compilation.html
+++ b/0.50.0/reference/jit-compilation.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="just-in-time-compilation">

--- a/0.50.0/reference/numpysupported.html
+++ b/0.50.0/reference/numpysupported.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-numpy-features">

--- a/0.50.0/reference/pysemantics.html
+++ b/0.50.0/reference/pysemantics.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deviations-from-python-semantics">

--- a/0.50.0/reference/pysupported.html
+++ b/0.50.0/reference/pysupported.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features">

--- a/0.50.0/reference/python27-eol.html
+++ b/0.50.0/reference/python27-eol.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="python-2-7-end-of-life-plan">

--- a/0.50.0/reference/types.html
+++ b/0.50.0/reference/types.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="types-and-signatures">

--- a/0.50.0/reference/utils.html
+++ b/0.50.0/reference/utils.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="utilities">

--- a/0.50.0/release-notes.html
+++ b/0.50.0/release-notes.html
@@ -1243,6 +1243,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="release-notes">

--- a/0.50.0/roc/device-functions.html
+++ b/0.50.0/roc/device-functions.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/0.50.0/roc/device-management.html
+++ b/0.50.0/roc/device-management.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-agents">

--- a/0.50.0/roc/examples.html
+++ b/0.50.0/roc/examples.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.50.0/roc/index.html
+++ b/0.50.0/roc/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-amd-roc-gpus">

--- a/0.50.0/roc/intrinsics.html
+++ b/0.50.0/roc/intrinsics.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/0.50.0/roc/kernels.html
+++ b/0.50.0/roc/kernels.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-hsa-kernels">

--- a/0.50.0/roc/memory.html
+++ b/0.50.0/roc/memory.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.50.0/roc/overview.html
+++ b/0.50.0/roc/overview.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.50.0/roc/ufunc.html
+++ b/0.50.0/roc/ufunc.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="roc-ufuncs-and-generalized-ufuncs">

--- a/0.50.0/search.html
+++ b/0.50.0/search.html
@@ -1241,6 +1241,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <noscript>

--- a/0.50.0/user/5minguide.html
+++ b/0.50.0/user/5minguide.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-5-minute-guide-to-numba">

--- a/0.50.0/user/cfunc.html
+++ b/0.50.0/user/cfunc.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-c-callbacks-with-cfunc">

--- a/0.50.0/user/cli.html
+++ b/0.50.0/user/cli.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="command-line-interface">

--- a/0.50.0/user/examples.html
+++ b/0.50.0/user/examples.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.50.0/user/faq.html
+++ b/0.50.0/user/faq.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="frequently-asked-questions">

--- a/0.50.0/user/generated-jit.html
+++ b/0.50.0/user/generated-jit.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="flexible-specializations-with-generated-jit">

--- a/0.50.0/user/index.html
+++ b/0.50.0/user/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="user-manual">

--- a/0.50.0/user/installing.html
+++ b/0.50.0/user/installing.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="installation">

--- a/0.50.0/user/jit-module.html
+++ b/0.50.0/user/jit-module.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-module-jitting-with-jit-module">

--- a/0.50.0/user/jit.html
+++ b/0.50.0/user/jit.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-code-with-jit">

--- a/0.50.0/user/jitclass.html
+++ b/0.50.0/user/jitclass.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-classes-with-jitclass">

--- a/0.50.0/user/overview.html
+++ b/0.50.0/user/overview.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.50.0/user/parallel.html
+++ b/0.50.0/user/parallel.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-parallelization-with-jit">

--- a/0.50.0/user/performance-tips.html
+++ b/0.50.0/user/performance-tips.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="performance-tips">

--- a/0.50.0/user/pycc.html
+++ b/0.50.0/user/pycc.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-code-ahead-of-time">

--- a/0.50.0/user/stencil.html
+++ b/0.50.0/user/stencil.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-stencil-decorator">

--- a/0.50.0/user/talks.html
+++ b/0.50.0/user/talks.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="talks-and-tutorials">

--- a/0.50.0/user/threading-layer.html
+++ b/0.50.0/user/threading-layer.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-threading-layers">

--- a/0.50.0/user/troubleshoot.html
+++ b/0.50.0/user/troubleshoot.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="troubleshooting-and-tips">

--- a/0.50.0/user/vectorize.html
+++ b/0.50.0/user/vectorize.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-numpy-universal-functions">

--- a/0.50.0/user/withobjmode.html
+++ b/0.50.0/user/withobjmode.html
@@ -1246,6 +1246,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="callback-into-the-python-interpreter-from-within-jit-ed-code">

--- a/0.50.1/cuda-reference/host.html
+++ b/0.50.1/cuda-reference/host.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-host-api">

--- a/0.50.1/cuda-reference/index.html
+++ b/0.50.1/cuda-reference/index.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-python-reference">

--- a/0.50.1/cuda-reference/kernel.html
+++ b/0.50.1/cuda-reference/kernel.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-kernel-api">

--- a/0.50.1/cuda-reference/memory.html
+++ b/0.50.1/cuda-reference/memory.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.50.1/cuda/cuda_array_interface.html
+++ b/0.50.1/cuda/cuda_array_interface.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-array-interface-version-2">

--- a/0.50.1/cuda/cudapysupported.html
+++ b/0.50.1/cuda/cudapysupported.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features-in-cuda-python">

--- a/0.50.1/cuda/device-functions.html
+++ b/0.50.1/cuda/device-functions.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/0.50.1/cuda/device-management.html
+++ b/0.50.1/cuda/device-management.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="device-management">

--- a/0.50.1/cuda/examples.html
+++ b/0.50.1/cuda/examples.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.50.1/cuda/external-memory.html
+++ b/0.50.1/cuda/external-memory.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="external-memory-management-emm-plugin-interface">

--- a/0.50.1/cuda/faq.html
+++ b/0.50.1/cuda/faq.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-frequently-asked-questions">

--- a/0.50.1/cuda/index.html
+++ b/0.50.1/cuda/index.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-cuda-gpus">

--- a/0.50.1/cuda/intrinsics.html
+++ b/0.50.1/cuda/intrinsics.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/0.50.1/cuda/ipc.html
+++ b/0.50.1/cuda/ipc.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="sharing-cuda-memory">

--- a/0.50.1/cuda/kernels.html
+++ b/0.50.1/cuda/kernels.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-cuda-kernels">

--- a/0.50.1/cuda/memory.html
+++ b/0.50.1/cuda/memory.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.50.1/cuda/overview.html
+++ b/0.50.1/cuda/overview.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.50.1/cuda/random.html
+++ b/0.50.1/cuda/random.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="random-number-generation">

--- a/0.50.1/cuda/reduction.html
+++ b/0.50.1/cuda/reduction.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="gpu-reduction">

--- a/0.50.1/cuda/simulator.html
+++ b/0.50.1/cuda/simulator.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="debugging-cuda-python-with-the-the-cuda-simulator">

--- a/0.50.1/cuda/ufunc.html
+++ b/0.50.1/cuda/ufunc.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-ufuncs-and-generalized-ufuncs">

--- a/0.50.1/developer/architecture.html
+++ b/0.50.1/developer/architecture.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-architecture">

--- a/0.50.1/developer/autogen_builtins_listing.html
+++ b/0.50.1/developer/autogen_builtins_listing.html
@@ -1249,6 +1249,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-builtins">

--- a/0.50.1/developer/autogen_cmath_listing.html
+++ b/0.50.1/developer/autogen_cmath_listing.html
@@ -1249,6 +1249,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-cmath">

--- a/0.50.1/developer/autogen_lower_listing.html
+++ b/0.50.1/developer/autogen_lower_listing.html
@@ -1249,6 +1249,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="lowering-listing">

--- a/0.50.1/developer/autogen_math_listing.html
+++ b/0.50.1/developer/autogen_math_listing.html
@@ -1249,6 +1249,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-math">

--- a/0.50.1/developer/autogen_numpy_listing.html
+++ b/0.50.1/developer/autogen_numpy_listing.html
@@ -1249,6 +1249,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-numpy">

--- a/0.50.1/developer/caching.html
+++ b/0.50.1/developer/caching.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-caching">

--- a/0.50.1/developer/contributing.html
+++ b/0.50.1/developer/contributing.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="contributing-to-numba">

--- a/0.50.1/developer/custom_pipeline.html
+++ b/0.50.1/developer/custom_pipeline.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="customizing-the-compiler">

--- a/0.50.1/developer/debugging.html
+++ b/0.50.1/developer/debugging.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-debugging">

--- a/0.50.1/developer/dispatching.html
+++ b/0.50.1/developer/dispatching.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="polymorphic-dispatching">

--- a/0.50.1/developer/environment.html
+++ b/0.50.1/developer/environment.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-object">

--- a/0.50.1/developer/generators.html
+++ b/0.50.1/developer/generators.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-generators">

--- a/0.50.1/developer/hashing.html
+++ b/0.50.1/developer/hashing.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-hashing">

--- a/0.50.1/developer/index.html
+++ b/0.50.1/developer/index.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="developer-manual">

--- a/0.50.1/developer/inlining.html
+++ b/0.50.1/developer/inlining.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-inlining">

--- a/0.50.1/developer/listings.html
+++ b/0.50.1/developer/listings.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings">

--- a/0.50.1/developer/literal.html
+++ b/0.50.1/developer/literal.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-literal-types">

--- a/0.50.1/developer/live_variable_analysis.html
+++ b/0.50.1/developer/live_variable_analysis.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="live-variable-analysis">

--- a/0.50.1/developer/numba-runtime.html
+++ b/0.50.1/developer/numba-runtime.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-runtime">

--- a/0.50.1/developer/repomap.html
+++ b/0.50.1/developer/repomap.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-map-of-the-numba-repository">

--- a/0.50.1/developer/rewrites.html
+++ b/0.50.1/developer/rewrites.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-numba-rewrite-pass-for-fun-and-optimization">

--- a/0.50.1/developer/roadmap.html
+++ b/0.50.1/developer/roadmap.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-project-roadmap">

--- a/0.50.1/developer/stencil.html
+++ b/0.50.1/developer/stencil.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-stencils">

--- a/0.50.1/developer/threading_implementation.html
+++ b/0.50.1/developer/threading_implementation.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-s-threading-implementation">

--- a/0.50.1/extending/entrypoints.html
+++ b/0.50.1/extending/entrypoints.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="registering-extensions-with-entry-points">

--- a/0.50.1/extending/high-level.html
+++ b/0.50.1/extending/high-level.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="high-level-extension-api">

--- a/0.50.1/extending/index.html
+++ b/0.50.1/extending/index.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="module-numba.extending">

--- a/0.50.1/extending/interval-example.html
+++ b/0.50.1/extending/interval-example.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="example-an-interval-type">

--- a/0.50.1/extending/low-level.html
+++ b/0.50.1/extending/low-level.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="low-level-extension-api">

--- a/0.50.1/extending/overloading-guide.html
+++ b/0.50.1/extending/overloading-guide.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-guide-to-using-overload">

--- a/0.50.1/genindex.html
+++ b/0.50.1/genindex.html
@@ -1242,6 +1242,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/0.50.1/glossary.html
+++ b/0.50.1/glossary.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="glossary">

--- a/0.50.1/index.html
+++ b/0.50.1/index.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-documentation">

--- a/0.50.1/proposals/cfunc.html
+++ b/0.50.1/proposals/cfunc.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-4-defining-c-callbacks">

--- a/0.50.1/proposals/extension-points.html
+++ b/0.50.1/proposals/extension-points.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-2-extension-points">

--- a/0.50.1/proposals/external-memory-management.html
+++ b/0.50.1/proposals/external-memory-management.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-7-cuda-external-memory-management-plugins">

--- a/0.50.1/proposals/index.html
+++ b/0.50.1/proposals/index.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-enhancement-proposals">

--- a/0.50.1/proposals/integer-typing.html
+++ b/0.50.1/proposals/integer-typing.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-1-changes-in-integer-typing">

--- a/0.50.1/proposals/jit-classes.html
+++ b/0.50.1/proposals/jit-classes.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-3-jit-classes">

--- a/0.50.1/proposals/type-inference.html
+++ b/0.50.1/proposals/type-inference.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-5-type-inference">

--- a/0.50.1/proposals/typing_recursion.html
+++ b/0.50.1/proposals/typing_recursion.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-6-typing-recursion">

--- a/0.50.1/py-modindex.html
+++ b/0.50.1/py-modindex.html
@@ -1242,6 +1242,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/0.50.1/reference/aot-compilation.html
+++ b/0.50.1/reference/aot-compilation.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="ahead-of-time-compilation">

--- a/0.50.1/reference/deprecation.html
+++ b/0.50.1/reference/deprecation.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deprecation-notices">

--- a/0.50.1/reference/envvars.html
+++ b/0.50.1/reference/envvars.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-variables">

--- a/0.50.1/reference/fpsemantics.html
+++ b/0.50.1/reference/fpsemantics.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="floating-point-pitfalls">

--- a/0.50.1/reference/index.html
+++ b/0.50.1/reference/index.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="reference-manual">

--- a/0.50.1/reference/jit-compilation.html
+++ b/0.50.1/reference/jit-compilation.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="just-in-time-compilation">

--- a/0.50.1/reference/numpysupported.html
+++ b/0.50.1/reference/numpysupported.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-numpy-features">

--- a/0.50.1/reference/pysemantics.html
+++ b/0.50.1/reference/pysemantics.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deviations-from-python-semantics">

--- a/0.50.1/reference/pysupported.html
+++ b/0.50.1/reference/pysupported.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features">

--- a/0.50.1/reference/python27-eol.html
+++ b/0.50.1/reference/python27-eol.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="python-2-7-end-of-life-plan">

--- a/0.50.1/reference/types.html
+++ b/0.50.1/reference/types.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="types-and-signatures">

--- a/0.50.1/reference/utils.html
+++ b/0.50.1/reference/utils.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="utilities">

--- a/0.50.1/release-notes.html
+++ b/0.50.1/release-notes.html
@@ -1244,6 +1244,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="release-notes">

--- a/0.50.1/roc/device-functions.html
+++ b/0.50.1/roc/device-functions.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/0.50.1/roc/device-management.html
+++ b/0.50.1/roc/device-management.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-agents">

--- a/0.50.1/roc/examples.html
+++ b/0.50.1/roc/examples.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.50.1/roc/index.html
+++ b/0.50.1/roc/index.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-amd-roc-gpus">

--- a/0.50.1/roc/intrinsics.html
+++ b/0.50.1/roc/intrinsics.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/0.50.1/roc/kernels.html
+++ b/0.50.1/roc/kernels.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-hsa-kernels">

--- a/0.50.1/roc/memory.html
+++ b/0.50.1/roc/memory.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/0.50.1/roc/overview.html
+++ b/0.50.1/roc/overview.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.50.1/roc/ufunc.html
+++ b/0.50.1/roc/ufunc.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="roc-ufuncs-and-generalized-ufuncs">

--- a/0.50.1/search.html
+++ b/0.50.1/search.html
@@ -1242,6 +1242,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <noscript>

--- a/0.50.1/user/5minguide.html
+++ b/0.50.1/user/5minguide.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-5-minute-guide-to-numba">

--- a/0.50.1/user/cfunc.html
+++ b/0.50.1/user/cfunc.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-c-callbacks-with-cfunc">

--- a/0.50.1/user/cli.html
+++ b/0.50.1/user/cli.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="command-line-interface">

--- a/0.50.1/user/examples.html
+++ b/0.50.1/user/examples.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/0.50.1/user/faq.html
+++ b/0.50.1/user/faq.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="frequently-asked-questions">

--- a/0.50.1/user/generated-jit.html
+++ b/0.50.1/user/generated-jit.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="flexible-specializations-with-generated-jit">

--- a/0.50.1/user/index.html
+++ b/0.50.1/user/index.html
@@ -1245,6 +1245,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="user-manual">

--- a/0.50.1/user/installing.html
+++ b/0.50.1/user/installing.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="installation">

--- a/0.50.1/user/jit-module.html
+++ b/0.50.1/user/jit-module.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-module-jitting-with-jit-module">

--- a/0.50.1/user/jit.html
+++ b/0.50.1/user/jit.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-code-with-jit">

--- a/0.50.1/user/jitclass.html
+++ b/0.50.1/user/jitclass.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-classes-with-jitclass">

--- a/0.50.1/user/overview.html
+++ b/0.50.1/user/overview.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/0.50.1/user/parallel.html
+++ b/0.50.1/user/parallel.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-parallelization-with-jit">

--- a/0.50.1/user/performance-tips.html
+++ b/0.50.1/user/performance-tips.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="performance-tips">

--- a/0.50.1/user/pycc.html
+++ b/0.50.1/user/pycc.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-code-ahead-of-time">

--- a/0.50.1/user/stencil.html
+++ b/0.50.1/user/stencil.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-stencil-decorator">

--- a/0.50.1/user/talks.html
+++ b/0.50.1/user/talks.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="talks-and-tutorials">

--- a/0.50.1/user/threading-layer.html
+++ b/0.50.1/user/threading-layer.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-threading-layers">

--- a/0.50.1/user/troubleshoot.html
+++ b/0.50.1/user/troubleshoot.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="troubleshooting-and-tips">

--- a/0.50.1/user/vectorize.html
+++ b/0.50.1/user/vectorize.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-numpy-universal-functions">

--- a/0.50.1/user/withobjmode.html
+++ b/0.50.1/user/withobjmode.html
@@ -1247,6 +1247,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="callback-into-the-python-interpreter-from-within-jit-ed-code">

--- a/dev/cuda-reference/host.html
+++ b/dev/cuda-reference/host.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-host-api">

--- a/dev/cuda-reference/index.html
+++ b/dev/cuda-reference/index.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-python-reference">

--- a/dev/cuda-reference/kernel.html
+++ b/dev/cuda-reference/kernel.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-kernel-api">

--- a/dev/cuda-reference/memory.html
+++ b/dev/cuda-reference/memory.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/dev/cuda/cuda_array_interface.html
+++ b/dev/cuda/cuda_array_interface.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-array-interface-version-2">

--- a/dev/cuda/cudapysupported.html
+++ b/dev/cuda/cudapysupported.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features-in-cuda-python">

--- a/dev/cuda/device-functions.html
+++ b/dev/cuda/device-functions.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/dev/cuda/device-management.html
+++ b/dev/cuda/device-management.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="device-management">

--- a/dev/cuda/examples.html
+++ b/dev/cuda/examples.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/dev/cuda/external-memory.html
+++ b/dev/cuda/external-memory.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="external-memory-management-emm-plugin-interface">

--- a/dev/cuda/faq.html
+++ b/dev/cuda/faq.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-frequently-asked-questions">

--- a/dev/cuda/index.html
+++ b/dev/cuda/index.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-cuda-gpus">

--- a/dev/cuda/intrinsics.html
+++ b/dev/cuda/intrinsics.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/dev/cuda/ipc.html
+++ b/dev/cuda/ipc.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="sharing-cuda-memory">

--- a/dev/cuda/kernels.html
+++ b/dev/cuda/kernels.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-cuda-kernels">

--- a/dev/cuda/memory.html
+++ b/dev/cuda/memory.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/dev/cuda/overview.html
+++ b/dev/cuda/overview.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/dev/cuda/random.html
+++ b/dev/cuda/random.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="random-number-generation">

--- a/dev/cuda/reduction.html
+++ b/dev/cuda/reduction.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="gpu-reduction">

--- a/dev/cuda/simulator.html
+++ b/dev/cuda/simulator.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="debugging-cuda-python-with-the-the-cuda-simulator">

--- a/dev/cuda/ufunc.html
+++ b/dev/cuda/ufunc.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="cuda-ufuncs-and-generalized-ufuncs">

--- a/dev/developer/architecture.html
+++ b/dev/developer/architecture.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-architecture">

--- a/dev/developer/autogen_builtins_listing.html
+++ b/dev/developer/autogen_builtins_listing.html
@@ -1263,6 +1263,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-builtins">

--- a/dev/developer/autogen_cmath_listing.html
+++ b/dev/developer/autogen_cmath_listing.html
@@ -1263,6 +1263,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-cmath">

--- a/dev/developer/autogen_lower_listing.html
+++ b/dev/developer/autogen_lower_listing.html
@@ -1263,6 +1263,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="lowering-listing">

--- a/dev/developer/autogen_math_listing.html
+++ b/dev/developer/autogen_math_listing.html
@@ -1263,6 +1263,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-math">

--- a/dev/developer/autogen_numpy_listing.html
+++ b/dev/developer/autogen_numpy_listing.html
@@ -1263,6 +1263,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings-for-numpy">

--- a/dev/developer/caching.html
+++ b/dev/developer/caching.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-caching">

--- a/dev/developer/contributing.html
+++ b/dev/developer/contributing.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="contributing-to-numba">

--- a/dev/developer/custom_pipeline.html
+++ b/dev/developer/custom_pipeline.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="customizing-the-compiler">

--- a/dev/developer/debugging.html
+++ b/dev/developer/debugging.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-debugging">

--- a/dev/developer/dispatching.html
+++ b/dev/developer/dispatching.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="polymorphic-dispatching">

--- a/dev/developer/environment.html
+++ b/dev/developer/environment.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-object">

--- a/dev/developer/generators.html
+++ b/dev/developer/generators.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-generators">

--- a/dev/developer/hashing.html
+++ b/dev/developer/hashing.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-hashing">

--- a/dev/developer/index.html
+++ b/dev/developer/index.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="developer-manual">

--- a/dev/developer/inlining.html
+++ b/dev/developer/inlining.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-inlining">

--- a/dev/developer/listings.html
+++ b/dev/developer/listings.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="listings">

--- a/dev/developer/literal.html
+++ b/dev/developer/literal.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-literal-types">

--- a/dev/developer/live_variable_analysis.html
+++ b/dev/developer/live_variable_analysis.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="live-variable-analysis">

--- a/dev/developer/numba-runtime.html
+++ b/dev/developer/numba-runtime.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-runtime">

--- a/dev/developer/repomap.html
+++ b/dev/developer/repomap.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-map-of-the-numba-repository">

--- a/dev/developer/rewrites.html
+++ b/dev/developer/rewrites.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-numba-rewrite-pass-for-fun-and-optimization">

--- a/dev/developer/roadmap.html
+++ b/dev/developer/roadmap.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-project-roadmap">

--- a/dev/developer/stencil.html
+++ b/dev/developer/stencil.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-stencils">

--- a/dev/developer/threading_implementation.html
+++ b/dev/developer/threading_implementation.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="notes-on-numba-s-threading-implementation">

--- a/dev/extending/entrypoints.html
+++ b/dev/extending/entrypoints.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="registering-extensions-with-entry-points">

--- a/dev/extending/high-level.html
+++ b/dev/extending/high-level.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="high-level-extension-api">

--- a/dev/extending/index.html
+++ b/dev/extending/index.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="module-numba.extending">

--- a/dev/extending/interval-example.html
+++ b/dev/extending/interval-example.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="example-an-interval-type">

--- a/dev/extending/low-level.html
+++ b/dev/extending/low-level.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="low-level-extension-api">

--- a/dev/extending/overloading-guide.html
+++ b/dev/extending/overloading-guide.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-guide-to-using-overload">

--- a/dev/genindex.html
+++ b/dev/genindex.html
@@ -1256,6 +1256,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/dev/glossary.html
+++ b/dev/glossary.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="glossary">

--- a/dev/index.html
+++ b/dev/index.html
@@ -1258,6 +1258,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-documentation">

--- a/dev/proposals/cfunc.html
+++ b/dev/proposals/cfunc.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-4-defining-c-callbacks">

--- a/dev/proposals/extension-points.html
+++ b/dev/proposals/extension-points.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-2-extension-points">

--- a/dev/proposals/external-memory-management.html
+++ b/dev/proposals/external-memory-management.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-7-cuda-external-memory-management-plugins">

--- a/dev/proposals/index.html
+++ b/dev/proposals/index.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-enhancement-proposals">

--- a/dev/proposals/integer-typing.html
+++ b/dev/proposals/integer-typing.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-1-changes-in-integer-typing">

--- a/dev/proposals/jit-classes.html
+++ b/dev/proposals/jit-classes.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-3-jit-classes">

--- a/dev/proposals/type-inference.html
+++ b/dev/proposals/type-inference.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-5-type-inference">

--- a/dev/proposals/typing_recursion.html
+++ b/dev/proposals/typing_recursion.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="nbep-6-typing-recursion">

--- a/dev/py-modindex.html
+++ b/dev/py-modindex.html
@@ -1256,6 +1256,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
 

--- a/dev/reference/aot-compilation.html
+++ b/dev/reference/aot-compilation.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="ahead-of-time-compilation">

--- a/dev/reference/deprecation.html
+++ b/dev/reference/deprecation.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deprecation-notices">

--- a/dev/reference/envvars.html
+++ b/dev/reference/envvars.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="environment-variables">

--- a/dev/reference/fpsemantics.html
+++ b/dev/reference/fpsemantics.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="floating-point-pitfalls">

--- a/dev/reference/index.html
+++ b/dev/reference/index.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="reference-manual">

--- a/dev/reference/jit-compilation.html
+++ b/dev/reference/jit-compilation.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="just-in-time-compilation">

--- a/dev/reference/numpysupported.html
+++ b/dev/reference/numpysupported.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-numpy-features">

--- a/dev/reference/pysemantics.html
+++ b/dev/reference/pysemantics.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="deviations-from-python-semantics">

--- a/dev/reference/pysupported.html
+++ b/dev/reference/pysupported.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-python-features">

--- a/dev/reference/types.html
+++ b/dev/reference/types.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="types-and-signatures">

--- a/dev/reference/utils.html
+++ b/dev/reference/utils.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="utilities">

--- a/dev/release-notes.html
+++ b/dev/release-notes.html
@@ -1258,6 +1258,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="release-notes">

--- a/dev/roc/device-functions.html
+++ b/dev/roc/device-functions.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-device-functions">

--- a/dev/roc/device-management.html
+++ b/dev/roc/device-management.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-agents">

--- a/dev/roc/examples.html
+++ b/dev/roc/examples.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/dev/roc/index.html
+++ b/dev/roc/index.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="numba-for-amd-roc-gpus">

--- a/dev/roc/intrinsics.html
+++ b/dev/roc/intrinsics.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="supported-atomic-operations">

--- a/dev/roc/kernels.html
+++ b/dev/roc/kernels.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="writing-hsa-kernels">

--- a/dev/roc/memory.html
+++ b/dev/roc/memory.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="memory-management">

--- a/dev/roc/overview.html
+++ b/dev/roc/overview.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/dev/roc/ufunc.html
+++ b/dev/roc/ufunc.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="roc-ufuncs-and-generalized-ufuncs">

--- a/dev/search.html
+++ b/dev/search.html
@@ -1256,6 +1256,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <noscript>

--- a/dev/user/5minguide.html
+++ b/dev/user/5minguide.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="a-5-minute-guide-to-numba">

--- a/dev/user/cfunc.html
+++ b/dev/user/cfunc.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-c-callbacks-with-cfunc">

--- a/dev/user/cli.html
+++ b/dev/user/cli.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="command-line-interface">

--- a/dev/user/examples.html
+++ b/dev/user/examples.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="examples">

--- a/dev/user/faq.html
+++ b/dev/user/faq.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="frequently-asked-questions">

--- a/dev/user/generated-jit.html
+++ b/dev/user/generated-jit.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="flexible-specializations-with-generated-jit">

--- a/dev/user/index.html
+++ b/dev/user/index.html
@@ -1259,6 +1259,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="user-manual">

--- a/dev/user/installing.html
+++ b/dev/user/installing.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="installation">

--- a/dev/user/jit-module.html
+++ b/dev/user/jit-module.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-module-jitting-with-jit-module">

--- a/dev/user/jit.html
+++ b/dev/user/jit.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-code-with-jit">

--- a/dev/user/jitclass.html
+++ b/dev/user/jitclass.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-python-classes-with-jitclass">

--- a/dev/user/overview.html
+++ b/dev/user/overview.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="overview">

--- a/dev/user/parallel.html
+++ b/dev/user/parallel.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="automatic-parallelization-with-jit">

--- a/dev/user/performance-tips.html
+++ b/dev/user/performance-tips.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="performance-tips">

--- a/dev/user/pycc.html
+++ b/dev/user/pycc.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="compiling-code-ahead-of-time">

--- a/dev/user/stencil.html
+++ b/dev/user/stencil.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="using-the-stencil-decorator">

--- a/dev/user/talks.html
+++ b/dev/user/talks.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="talks-and-tutorials">

--- a/dev/user/threading-layer.html
+++ b/dev/user/threading-layer.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="the-threading-layers">

--- a/dev/user/troubleshoot.html
+++ b/dev/user/troubleshoot.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="troubleshooting-and-tips">

--- a/dev/user/vectorize.html
+++ b/dev/user/vectorize.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="creating-numpy-universal-functions">

--- a/dev/user/withobjmode.html
+++ b/dev/user/withobjmode.html
@@ -1261,6 +1261,11 @@
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div class="admonition warning">
+             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
+             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
+           </div>
+
            <div itemprop="articleBody">
             
   <div class="section" id="callback-into-the-python-interpreter-from-within-jit-ed-code">


### PR DESCRIPTION
Issues like numba/numba#7876 keep coming up because of SEO issues. This PR adds a banner to all the RTD-themed pages (which are the ones people mostly land on, versions 0.49.0 onwards and latest + dev) to warn of the outdated documentation and link to the up-to-date docs. This was generated by running the command:

```
find -name "*.html" | xargs sed  '/div role=\"main\"/r ../outdated.txt' -i
```

where the `outdated.txt` file contains:

```
           <div class="admonition warning">
             <p class="admonition-title">OUTDATED DOCUMENTATION</p>
             <p>You are viewing archived documentation from the old Numba documentation site. The current documentation is located at <a href="https://numba.readthedocs.io">https://numba.readthedocs.io</a>.</p>
           </div>
```

The result is that the pages all have this banner at the top now:

![outdated_000](https://user-images.githubusercontent.com/535640/156415800-7b9d895c-267b-40dc-869d-8d8399c6fe6a.png)

